### PR TITLE
add bin and obj folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 xcuserdata/
 *.xcworkspace/
+
+bin/
+obj/


### PR DESCRIPTION
Core clutters the git status with a bunch of build artifacts in bin/ and obj/ so this adds those folders to gitignore.